### PR TITLE
Change "items" property to be mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ displayName: Category Result
 type: Paysera.Result
 properties:
   items:
-    required: false
+    required: true
     displayName: Categories
     type: array
     items:


### PR DESCRIPTION
Change `items` property to be mandatory in example of a custom result
type, where it doesn't make sense for that property to be optional.